### PR TITLE
Don't raise error on last cell being unexecuted

### DIFF
--- a/nbcheckorder/__init__.py
+++ b/nbcheckorder/__init__.py
@@ -18,7 +18,7 @@ def are_cells_sequential(filename):
         cell_number = i + 1
         execution_count = cell.get('execution_count')
 
-        if (execution_count is None):
+        if (execution_count is None) and not (cell_number == len(code_cells)):
             print(f'{filename}: Notebook contains unexecuted cells ({cell_number=})')
             return False
         else:


### PR DESCRIPTION
Juptyer typically trails notebooks with a final empty cell. This is similar to the way most python formatters trail files with a single, empty newline. Currently this checker fails on that last empty cell which means that you typically have to go back and manually delete the empty cell.