### PR TITLE
Add option to ignore unexecuted notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Pre-commit hook to check the order of Jupyter notebook cells.
 
 Prevents notebooks from being commited if the cell order is not sequential. This can avoid hidden state, or make sure that WIP notebooks are not commited by accident.
 
+Optionally, notebooks with no executed cells can be ignored by passing the `--allow-unexecuted-notebooks` flag.
+
 Try it out by running:
 
 ```bash
@@ -21,4 +23,5 @@ Sample `.pre-commit-config.yaml`:
     rev: v0.2.0
     hooks:
       - id: nbcheckorder
+        args: [--allow-unexecuted-notebooks]
 ```

--- a/nbcheckorder/__init__.py
+++ b/nbcheckorder/__init__.py
@@ -36,14 +36,29 @@ def are_cells_sequential(filename):
     return True
 
 
+def are_all_cells_unexecuted(filename):
+    node = nbformat.read(filename, as_version=4)
+    cells = node['cells']
+
+    code_cells = [cell for cell in cells if cell['cell_type'] == 'code']
+    return all(cell.get('execution_count') is None for cell in code_cells)
+
+
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to check.')
+    parser.add_argument(
+        '--allow-unexecuted-notebooks',
+        help='Will allow notebooks in which no cells are executed',
+        action='store_true',
+    )
     args = parser.parse_args(argv)
 
     retval = 0
 
     for filename in args.filenames:
+        if args.allow_unexecuted_notebooks and are_all_cells_unexecuted(filename):
+            continue
         if not are_cells_sequential(filename):
             retval = 1
 

--- a/tests/test_nbcheckorder.py
+++ b/tests/test_nbcheckorder.py
@@ -1,4 +1,4 @@
-from nbcheckorder import are_cells_sequential
+from nbcheckorder import are_cells_sequential, are_all_cells_unexecuted
 import pytest
 from pathlib import Path
 
@@ -9,9 +9,23 @@ TESTS_DIR = Path(__file__).parent
 (
     (TESTS_DIR / 'dirty_order.ipynb', False),
     (TESTS_DIR / 'clean_order.ipynb', True),
+    (TESTS_DIR / 'unexecuted.ipynb', False),
 ))
 
 def test_are_cells_sequential(filename, expected_result):
     result = are_cells_sequential(filename)
 
     assert result == expected_result
+
+@pytest.mark.parametrize("filename,expected_result", 
+(
+    (TESTS_DIR / 'dirty_order.ipynb', False),
+    (TESTS_DIR / 'clean_order.ipynb', False),
+    (TESTS_DIR / 'unexecuted.ipynb', True),
+))
+
+def test_are_all_cells_unexecuted(filename, expected_result):
+    result = are_all_cells_unexecuted(filename)
+
+    assert result == expected_result
+

--- a/tests/unexecuted.ipynb
+++ b/tests/unexecuted.ipynb
@@ -1,0 +1,75 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3cda8036",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"this is cell one\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e92aaad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"this is cell two\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d93aea3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"this is cell three\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "935f5a1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"this is cell four\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99de0150",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"this is cell five\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Hello!

This pre-commit hook is used in instamatic, where some notebooks contain no executed cells. 
In my opinion, these should pass an execution order check.

To avoid breaking anything, this PR adds an optional flag to allow these files (off by default).
If such a feature is unfitting for this hook, feel free to decline this PR. There are other ways to work around this, e.g. ignoring them in .pre-commit-config.yaml